### PR TITLE
INSIGHT-28914: excuse bots from danger

### DIFF
--- a/validate-pr/dangerfile.js
+++ b/validate-pr/dangerfile.js
@@ -1,13 +1,19 @@
 'use strict';
 
 // always import danger first
-const { fail, danger } = require('danger');
+const { fail, warn, danger } = require('danger');
 
 // danger-plugin-jira-issue exports a default function to hacking to get it imported
 const jiraIssue = require('danger-plugin-jira-issue').default;
 const _ = require('lodash');
 
 const pr = _.get(danger, 'github.pr');
+
+if (_.get(pr, 'user.type') === 'Bot') {
+    warn('Skipping PR title validation since this is from a bot.  If you wish to merge this PR, please open an issue and update the title!');
+    process.exit(0);
+}
+
 const title = _.trim(_.get(pr, 'title'))
 let issueType;
 let passed;


### PR DESCRIPTION
## Description
Dependabot toils away opening up PRs and we mark them all as failures because it doesn’t open them with the correct PR titles.  And it can’t because it doesn’t open Jira issues for each PR and really, would we want it to?  Hasn't 'bendy done enough?  Let’s just skip the PR title validation for Dependabot, so we can see whether the PRs pass CI tests.

## Tests [REQUIRED]
<!-- Address each of the following sections regarding testing -->

### Manual Testing 
- [X] I have manually tested this change.
Changed https://github.com/mediafly/web-client/pull/3623 to point at the new action branch, got:

<img width="944" alt="image" src="https://github.com/mediafly/github-actions/assets/553428/c2164c34-8a46-4734-a324-1100e1eb61b9">

<!-- Please document HOW you tested it. "manually" is not enough, document the steps you performed. Screenshots can help here! -->

### Automated Tests
- [ ] I have identified existing automated tests, and/or added new automated tests.
n/a
<!-- Please document the automated tests that will verify this in the future. If relying on existing tests link to specific tests you think will catch regressions -->

### Post-release verification
- [ ] I have documented how I will verify this change in production
will re-run the workflow on a dependabot pr and a non-dependabot PR and check that they both work.
